### PR TITLE
Update installation-user-provisioned-validating-dns.adoc

### DIFF
--- a/modules/installation-user-provisioned-validating-dns.adoc
+++ b/modules/installation-user-provisioned-validating-dns.adoc
@@ -47,7 +47,7 @@ $ dig +noall +answer @<nameserver_ip> api.<cluster_name>.<base_domain> <1>
 .Example output
 [source,terminal]
 ----
-api.ocp4.example.com.		0	IN	A	192.168.1.5
+api.ocp4.example.com.		604800	IN	A	192.168.1.5
 ----
 
 .. Perform a lookup against the Kubernetes internal API record name. Check that the result points to the IP address of the API load balancer:
@@ -60,7 +60,7 @@ $ dig +noall +answer @<nameserver_ip> api-int.<cluster_name>.<base_domain>
 .Example output
 [source,terminal]
 ----
-api-int.ocp4.example.com.		0	IN	A	192.168.1.5
+api-int.ocp4.example.com.		604800	IN	A	192.168.1.5
 ----
 
 .. Test an example `*.apps.<cluster_name>.<base_domain>` DNS wildcard lookup. All of the application wildcard lookups must resolve to the IP address of the application ingress load balancer:
@@ -73,7 +73,7 @@ $ dig +noall +answer @<nameserver_ip> random.apps.<cluster_name>.<base_domain>
 .Example output
 [source,terminal]
 ----
-random.apps.ocp4.example.com.		0	IN	A	192.168.1.5
+random.apps.ocp4.example.com.		604800	IN	A	192.168.1.5
 ----
 +
 [NOTE]
@@ -91,7 +91,7 @@ $ dig +noall +answer @<nameserver_ip> console-openshift-console.apps.<cluster_na
 .Example output
 [source,terminal]
 ----
-console-openshift-console.apps.ocp4.example.com. 0 IN	A 192.168.1.5
+console-openshift-console.apps.ocp4.example.com. 604800 IN	A 192.168.1.5
 ----
 
 .. Run a lookup against the bootstrap DNS record name. Check that the result points to the IP address of the bootstrap node:
@@ -104,7 +104,7 @@ $ dig +noall +answer @<nameserver_ip> bootstrap.<cluster_name>.<base_domain>
 .Example output
 [source,terminal]
 ----
-bootstrap.ocp4.example.com.		0	IN	A	192.168.1.96
+bootstrap.ocp4.example.com.		604800	IN	A	192.168.1.96
 ----
 
 .. Use this method to perform lookups against the DNS record names for the control plane and compute nodes. Check that the results correspond to the IP addresses of each node.
@@ -121,8 +121,8 @@ $ dig +noall +answer @<nameserver_ip> -x 192.168.1.5
 .Example output
 [source,terminal]
 ----
-5.1.168.192.in-addr.arpa. 0	IN	PTR	api-int.ocp4.example.com. <1>
-5.1.168.192.in-addr.arpa. 0	IN	PTR	api.ocp4.example.com. <2>
+5.1.168.192.in-addr.arpa. 604800	IN	PTR	api-int.ocp4.example.com. <1>
+5.1.168.192.in-addr.arpa. 604800	IN	PTR	api.ocp4.example.com. <2>
 ----
 +
 <1> Provides the record name for the Kubernetes internal API.
@@ -143,7 +143,7 @@ $ dig +noall +answer @<nameserver_ip> -x 192.168.1.96
 .Example output
 [source,terminal]
 ----
-96.1.168.192.in-addr.arpa. 0	IN	PTR	bootstrap.ocp4.example.com.
+96.1.168.192.in-addr.arpa. 604800	IN	PTR	bootstrap.ocp4.example.com.
 ----
 
 .. Use this method to perform reverse lookups against the IP addresses for the control plane and compute nodes. Check that the results correspond to the DNS record names of each node.


### PR DESCRIPTION
### Incorrect TTL values

In the example of DNS configuration for user-provisioned clusters:

Link to docs preview:
https://docs.openshift.com/container-platform/4.14/installing/installing_vsphere/installing-vsphere.html#installation-dns-user-infra-example_installing-vsphere


The TTL value is 1w, according to that the output of dig command should be "604800"



Sample DNS zone database:
```
$TTL 1W
@       IN      SOA     ns1.example.com.        root (
                        2019070700      ; serial
                        3H              ; refresh (3 hours)
                        30M             ; retry (30 minutes)
                        2W              ; expiry (2 weeks)
                        1W )            ; minimum (1 week)
        IN      NS      ns1.example.com.
        IN      MX 10   smtp.example.com.
...
...
```

Sample DNS zone database for reverse records:
```
$TTL 1W
@       IN      SOA     ns1.example.com.        root (
                        2019070700      ; serial
                        3H              ; refresh (3 hours)
                        30M             ; retry (30 minutes)
                        2W              ; expiry (2 weeks)
                        1W )            ; minimum (1 week)
        IN      NS      ns1.example.com.
```



This is incorrect value:
```
$ dig +noall +answer @<nameserver_ip> api.<cluster_name>.<base_domain>
api.ocp4.example.com.           0       IN      A       192.168.1.5
```

The correct value according to TTL 1w
```
$ dig +noall +answer @<nameserver_ip> api.<cluster_name>.<base_domain>
api.ocp4.example.com.           604800       IN      A       192.168.1.5
```

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): All inducing 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->



Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
